### PR TITLE
Add unit tests for org.springframework.beans.PropertyAccessorUtils

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/PropertyAccessorUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/PropertyAccessorUtilsTests.java
@@ -29,7 +29,59 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class PropertyAccessorUtilsTests {
 
 	@Test
+	public void testGetPropertyName() {
+		assertThat(PropertyAccessorUtils.getPropertyName("foo"))
+				.isEqualTo("foo");
+		assertThat(PropertyAccessorUtils.getPropertyName("[foo]"))
+				.isEqualTo("");
+	}
+
+	@Test
+	public void testIsNestedOrIndexedProperty() {
+		assertThat(PropertyAccessorUtils.isNestedOrIndexedProperty(null))
+				.isFalse();
+		assertThat(PropertyAccessorUtils.isNestedOrIndexedProperty("foo"))
+				.isFalse();
+		assertThat(PropertyAccessorUtils.isNestedOrIndexedProperty("[foo]"))
+				.isTrue();
+		assertThat(PropertyAccessorUtils.isNestedOrIndexedProperty("foo.txt"))
+				.isTrue();
+	}
+
+	@Test
+	public void testGetFirstNestedPropertySeparatorIndex() {
+		assertThat(PropertyAccessorUtils
+				.getFirstNestedPropertySeparatorIndex("[foo]")).isEqualTo(-1);
+		assertThat(PropertyAccessorUtils
+				.getFirstNestedPropertySeparatorIndex("foo.txt")).isEqualTo(3);
+	}
+
+	@Test
+	public void testGetLastNestedPropertySeparatorIndex() {
+		assertThat(PropertyAccessorUtils
+				.getLastNestedPropertySeparatorIndex("[foo]")).isEqualTo(-1);
+		assertThat(PropertyAccessorUtils
+				.getLastNestedPropertySeparatorIndex("foo.txt")).isEqualTo(3);
+	}
+
+	@Test
+	public void testMatchesProperty() {
+		assertThat(PropertyAccessorUtils
+				.matchesProperty("foo", "bar")).isFalse();
+		assertThat(PropertyAccessorUtils
+				.matchesProperty("foobar", "foo")).isFalse();
+		assertThat(PropertyAccessorUtils
+				.matchesProperty("bar[foo]", "foo")).isFalse();
+
+		assertThat(PropertyAccessorUtils
+				.matchesProperty("foo", "foo")).isTrue();
+		assertThat(PropertyAccessorUtils
+				.matchesProperty("foo[bar]", "foo")).isTrue();
+	}
+
+	@Test
 	public void testCanonicalPropertyName() {
+		assertThat(PropertyAccessorUtils.canonicalPropertyName(null)).isEqualTo("");
 		assertThat(PropertyAccessorUtils.canonicalPropertyName("map")).isEqualTo("map");
 		assertThat(PropertyAccessorUtils.canonicalPropertyName("map[key1]")).isEqualTo("map[key1]");
 		assertThat(PropertyAccessorUtils.canonicalPropertyName("map['key1']")).isEqualTo("map[key1]");
@@ -51,6 +103,7 @@ public class PropertyAccessorUtilsTests {
 											"map[key1][key2]", "map[key1].name", "map[key1].name", "map[key1].name"};
 
 		assertThat(Arrays.equals(canonical, PropertyAccessorUtils.canonicalPropertyNames(original))).isTrue();
+		assertThat(PropertyAccessorUtils.canonicalPropertyNames(null)).isNull();
 	}
 
 }


### PR DESCRIPTION
I've analysed your codebase and noticed that `org.springframework.beans.PropertyAccessorUtils` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.